### PR TITLE
WFCatalogCollector: follow symlinks in SDS

### DIFF
--- a/collector/WFCatalogCollector.py
+++ b/collector/WFCatalogCollector.py
@@ -394,7 +394,7 @@ class WFCatalogCollector():
     elif CONFIG['STRUCTURE'] == 'SDS':
       collectedFiles = []
       directory = os.path.join(CONFIG['ARCHIVE_ROOT'], year)
-      for subdir, dirs, files in os.walk(directory):
+      for subdir, dirs, files in os.walk(directory, followlinks=True):
         for file in files:
           if file.endswith(jday) and os.path.isfile(os.path.join(subdir, file)):
             collectedFiles.append(os.path.join(subdir, file))


### PR DESCRIPTION
This makes the collector follow directory symlinks in the SDS structure. Alternatively this could be controlled via config json, but I don't see how this could hurt existing instances.

See https://github.com/EIDA/userfeedback/issues/6