### PR TITLE
Fix empty location identifier for HTTP GET

### DIFF
--- a/service/runtests.js
+++ b/service/runtests.js
@@ -46,6 +46,24 @@ var suite = function () {
   }
 
   /*
+   * function this.testEmptyLocationGET
+   * test should result in an empty response (i.e. HTTP status code 204)
+   */
+  this.testEmptyLocationGET = function(callback) {
+
+    var options = getOptions(
+      'GET',
+      CONFIG.BASE_URL + 'query?net=NET&sta=STA&cha=CHA&LOC=--&' +
+      'start=2020-01-01&end=2020-01-02');
+
+    http.request(options, function(response) {
+      var err = (response.statusCode === 204) ?
+        null : "Invalid response code: " + response.statusCode;
+      callback(err)
+    }).end();
+
+  }
+  /*
    * function this.testStartTimeFuture
    * test start time in the future (2133)
    */

--- a/service/server.js
+++ b/service/server.js
@@ -1514,6 +1514,7 @@ module.exports = function(CONFIG, WFCatalogCallback) {
       'string': /^([0-9a-z_*?]+)$/i,
       'stringList': /^([0-9a-z]+,){0,}([0-9a-z]+)$/i,
       'stringListWildcards': /^([0-9a-z_*?]+,){0,}([0-9a-z_*?]+)$/i,
+      'stringLocListWildcards': /^(([0-9a-z_*?]+|--),){0,}([0-9a-z_*?]+|--)$/i,
       'floatList': /^(\s*-?\d+(\.\d+)?)(\s*,\s*-?\d+(\.\d+)?)*$/,
       'intList': /^(\d+(,\d+)*)?$/,
       'query': /^\?([\w-?.:*,%]+(=[\w-?.:*,%]*)?(&[\w-?.:*,%]+(=[\w-?.:*,%]*)?)*)?$/

--- a/service/static/types.json
+++ b/service/static/types.json
@@ -39,7 +39,7 @@
 
   "net": "stringListWildcards",
   "sta": "stringListWildcards",
-  "loc": "stringListWildcards",
+  "loc": "stringLocListWildcards",
   "cha": "stringListWildcards",
 
   "nsam": "int",


### PR DESCRIPTION
Allow specifying an empty location identifier i.e. `--` for HTTP GET requests, too. Treat the location identifier both for HTTP GET and POST requests equally.

This PR fixes #17.