### PR TITLE
[service] Add nodata parameter, and remove version from configuration

### DIFF
--- a/service/application.wadl
+++ b/service/application.wadl
@@ -48,6 +48,11 @@
             <param name="longestonly" style="query" default="false" type="xsd:boolean"/>
             <param name="csegments" style="query" default="false" type="xsd:boolean"/>
  
+            <param name="nodata" style="query" type="xsd:int" default="204">
+              <option value="204"/>
+              <option value="404"/>
+            </param>
+
             <!-- Metrics may be appended with a logical operator -->
             <param name="sample_rate" style="query" type="xsd:float"/>
             <param name="record_length" style="query" type="xsd:float"/>

--- a/service/configuration.json.sample
+++ b/service/configuration.json.sample
@@ -2,8 +2,6 @@
   "NAME": "ODC-WFCATALOG",
   "ARCHIVE": "ORFEUS ODC/KNMI",
   "AGENT": "ObsPy mSEED-QC",
-  "VERSION": "1.0.1",
-  "VERSION_DATE": "2025.03.10",
   "DOCUMENTATION_URI": "ENTER_URI_HERE",
   "BASE_URL": "/eidaws/wfcatalog/1/",
   "HOST": "127.0.0.1",

--- a/service/server.js
+++ b/service/server.js
@@ -481,6 +481,7 @@ module.exports = function (CONFIG, WFCatalogCallback) {
       format: "json",
       include: "default",
       gran: "day",
+      nodata: 204,
       longestonly: getStringAsBoolean(req.WFCatalog.query.longestonly),
       csegments: getStringAsBoolean(req.WFCatalog.query.csegments),
     };
@@ -550,6 +551,20 @@ module.exports = function (CONFIG, WFCatalogCallback) {
       }
       req.WFCatalog.options.format = req.WFCatalog.query.format;
       delete req.WFCatalog.query.format;
+    }
+
+    // Check the nodata; only 204 or 404 are supported 
+    if (req.WFCatalog.query.nodata) {
+      if (!["204", "404"].inArray(req.WFCatalog.query.nodata)) {
+        return sendErrorPage(
+          req,
+          res,
+          ERROR.NODATA_UNSUPPORTED,
+          req.WFCatalog.query.nodata
+        );
+      }
+      req.WFCatalog.options.nodata = parseInt(req.WFCatalog.query.nodata);
+      delete req.WFCatalog.query.nodata;
     }
 
     // If [minimumlength] or [longestonly] is specified
@@ -858,9 +873,9 @@ module.exports = function (CONFIG, WFCatalogCallback) {
       return res.status(499).end();
     }
 
-    // If no documents, return 204
+    // If no documents, return 204 or 404
     if (!req.WFCatalog.nDocuments) {
-      return res.status(204).end();
+      return res.status(req.WFCatalog.options.nodata).end();
     }
 
     // Close JSON and celebrate a succesful request

--- a/service/server.js
+++ b/service/server.js
@@ -64,6 +64,8 @@ module.exports = function (CONFIG, WFCatalogCallback) {
   var WFCatalogger;
   setupLogger();
 
+  const VERSION = "1.0.2"
+
   // The service is powered by express
   var WFCatalog = require("express")();
 
@@ -100,7 +102,7 @@ module.exports = function (CONFIG, WFCatalogCallback) {
    */
   WFCatalog.get(CONFIG.BASE_URL + "version", function (req, res, next) {
     res.setHeader("Content-Type", "text/plain");
-    res.status(200).send(CONFIG.VERSION);
+    res.status(200).send(VERSION);
   });
 
   /*
@@ -1390,7 +1392,7 @@ module.exports = function (CONFIG, WFCatalogCallback) {
       "Request Submitted:",
       req.WFCatalog.requestSubmitted,
       "Service Version:",
-      CONFIG.VERSION,
+      VERSION,
     ].join("\n");
 
     return res.send(response);

--- a/service/static/dbmap.json
+++ b/service/static/dbmap.json
@@ -74,6 +74,7 @@
   "format": "format",
   "longestonly": "longestonly",
   "csegments": "csegments",
-  "include": "include"
+  "include": "include",
+  "nodata": "nodata"
 
 }

--- a/service/static/errors.json
+++ b/service/static/errors.json
@@ -78,6 +78,10 @@
     "code": 400,
     "msg": "The requested granularity is not supported: %s"
   },
+  "NODATA_UNSUPPORTED": {
+    "code": 400,
+    "msg": "The requested nodata is not supported: %s"
+  },
   "INCLUDE_UNSUPPORTED": {
     "code": 400,
     "msg": "The requested include options is not supported: %s"

--- a/service/static/types.json
+++ b/service/static/types.json
@@ -59,6 +59,7 @@
   "olen": "float",
   "avail": "float",
 
-  "minlen": "float"
+  "minlen": "float",
+  "nodata": "int"
 
 }


### PR DESCRIPTION
Add a `nodata` query parameter to the webservice, acting similarly to the one seen in FDSN webservices.

Additionally, removed the service version from its configuration file. Now it is just a hard-coded value in the source code.

Resolves #37 and #42