### PR TITLE
Return HTTP 413 if response exceeds configured `MAXIMUM_BYTES_RETURNED`

### DIFF
--- a/service/configuration.json.sample
+++ b/service/configuration.json.sample
@@ -36,5 +36,6 @@
     "COLLECTION": "daily_streams",
     "C_COLLECTION": "c_segments"
   },
-  "CLOSED": false
+  "CLOSED": false,
+  "VERSION": "1.0.3",
 }

--- a/service/runtests.js
+++ b/service/runtests.js
@@ -696,7 +696,7 @@ var suite = function () {
   * Tests an response too large to return as configured by MAXIMUM_BYTES_RETURNED > 0
   */
   this.testPayloadTooLarge = function(callback) {
-    var options = getOptions(
+    const options = getOptions(
       "GET",
       CONFIG.BASE_URL +
         "query?network=NL&station=G233&include=sample&start=2024-01-01&end=2024-01-31"
@@ -708,7 +708,7 @@ var suite = function () {
     http
       .request(options, function (response) {
         response.on("data", function (data) {
-          var err = compareResponse(data, {
+          const err = compareResponse(data, {
             message: {
               code: ERROR.MAXIMUM_PAYLOAD_EXCEEDED.code,
               msg: ERROR.MAXIMUM_PAYLOAD_EXCEEDED.msg

--- a/service/runtests.js
+++ b/service/runtests.js
@@ -691,6 +691,40 @@ var suite = function () {
       })
       .end();
   };
+  
+  /*
+  * Tests an response too large to return as configured by MAXIMUM_BYTES_RETURNED > 0
+  */
+  this.testPayloadTooLarge = function(callback) {
+    var options = getOptions(
+      "GET",
+      CONFIG.BASE_URL +
+        "query?network=NL&station=G233&include=sample&start=2024-01-01&end=2024-01-31"
+    );
+
+    const prevMaxBytes = CONFIG.MAXIMUM_BYTES_RETURNED
+    CONFIG.MAXIMUM_BYTES_RETURNED = 10e3
+
+    http
+      .request(options, function (response) {
+        response.on("data", function (data) {
+          var err = compareResponse(data, {
+            message: {
+              code: ERROR.MAXIMUM_PAYLOAD_EXCEEDED.code,
+              msg: ERROR.MAXIMUM_PAYLOAD_EXCEEDED.msg
+            },
+            request: options.path,
+            "version":"1.0.3"
+          });
+
+          CONFIG.MAXIMUM_BYTES_RETURNED = prevMaxBytes
+
+          callback(err);
+        });
+      })
+      .end();
+      
+  };
 };
 
 function compareResponse(a, b) {

--- a/service/runtests.js
+++ b/service/runtests.js
@@ -713,8 +713,7 @@ var suite = function () {
               code: ERROR.MAXIMUM_PAYLOAD_EXCEEDED.code,
               msg: ERROR.MAXIMUM_PAYLOAD_EXCEEDED.msg
             },
-            request: options.path,
-            "version":"1.0.3"
+            request: options.path
           });
 
           CONFIG.MAXIMUM_BYTES_RETURNED = prevMaxBytes

--- a/service/server.js
+++ b/service/server.js
@@ -692,6 +692,7 @@ module.exports = function (CONFIG, WFCatalogCallback) {
     req.WFCatalog.nDocuments = 0;
     req.WFCatalog.nBytes = 0;
     req.WFCatalog.nContinuous = 0;
+    req.WFCatalog.responseChunks = [];
 
     // Define variables for hoisting
     var documentPointer;
@@ -740,10 +741,10 @@ module.exports = function (CONFIG, WFCatalogCallback) {
       // or the document is one trace, write the daily metric document
       // and proceed along the cursor
       if (!req.WFCatalog.options.csegments || doc.cont) {
-        if (writeStream(req, res, documentPointer)) {
+        if (buildResponse(req, res, documentPointer)) {
           return cursor.next(processDailyStream);
         }
-        return endResponse(req, res);
+        return sendErrorPage(req, res, ERROR.MAXIMUM_PAYLOAD_EXCEEDED);
       }
 
       // We are required to collect continuous segments
@@ -792,11 +793,11 @@ module.exports = function (CONFIG, WFCatalogCallback) {
 
       // The cursor has been exhausted; write to stream
       // and proceed with the next daily stream
-      if (writeStream(req, res, documentPointer)) {
+      if (buildResponse(req, res, documentPointer)) {
         return cursor.next(processDailyStream);
       }
 
-      return endResponse(req, res);
+      return sendErrorPage(req, res, ERROR.MAXIMUM_PAYLOAD_EXCEEDED);
     }
   });
 
@@ -833,15 +834,16 @@ module.exports = function (CONFIG, WFCatalogCallback) {
     }
   });
 
-  /* @ function writeStream
-   * Handler for writing to the writeable response stream
-   * counts the nBytes shipped and properly parses the
-   * JSON body
+  /**
+   * @ function writeStream
+   * Handler for writing response stream
+   * 
+   * @param {Object} req: Express Request Object
+   * @param {Object} res: Express Response Object
+   * @param {object} data: Stringified JSON Query result
+   * 
    */
   function writeStream(req, res, data) {
-    var json = JSON.stringify(data);
-    req.WFCatalog.nBytes += Buffer.byteLength(json);
-
     // Delimit a document by a comma or open the JSON
     if (req.WFCatalog.nDocuments === 1) {
       res.write("[");
@@ -849,12 +851,31 @@ module.exports = function (CONFIG, WFCatalogCallback) {
       res.write(",");
     }
 
-    res.write(json);
+    req.WFCatalog.nBytes += 1;
+    res.write(data);
+  }
 
-    // Set to 0 for no maximum
+  /**
+   * @ function buildResponse 
+   * Handler for building the response.
+   * Checks if the response is within set limits
+   * 
+   * @param {Object} req: Express Request Object
+   * @param {Object} res: Express Response Object
+   * @param {object} data: Query result in JSON
+   * 
+   */
+  function buildResponse(req, res, data) {
+    var json = JSON.stringify(data);
+    req.WFCatalog.nBytes += Buffer.byteLength(json);
+    
+    // No limit on returnable data, therefore stream the response
     if (CONFIG.MAXIMUM_BYTES_RETURNED === 0) {
+      writeStream(req, res, json);
       return true;
     }
+    
+    req.WFCatalog.responseChunks.push(data);
 
     return req.WFCatalog.nBytes < CONFIG.MAXIMUM_BYTES_RETURNED;
   }
@@ -878,10 +899,16 @@ module.exports = function (CONFIG, WFCatalogCallback) {
       return res.status(req.WFCatalog.options.nodata).end();
     }
 
-    // Close JSON and celebrate a succesful request
-    res.write("]");
+    // No limit of returnable data was defined, close the stream and return
+    if (CONFIG.MAXIMUM_BYTES_RETURNED === 0) {
+      res.write("]");
+      req.WFCatalog.nBytes += 1;
 
-    return res.status(200).end();
+      return res.end();
+    }
+
+    // A limit of returnable data was defined
+    return res.status(200).json(req.WFCatalog.responseChunks);
   }
 
   /*

--- a/service/server.js
+++ b/service/server.js
@@ -64,7 +64,7 @@ module.exports = function (CONFIG, WFCatalogCallback) {
   var WFCatalogger;
   setupLogger();
 
-  const VERSION = "1.0.2"
+  const VERSION = "1.0.3"
 
   // The service is powered by express
   var WFCatalog = require("express")();


### PR DESCRIPTION
Addresses #39 and #43 where responses were abruptly cut-off.

Changes proposed here does 2 things,

1. Gets rid of streaming when configured `MAXIMUM_BYTES_RETURNED > 0`. 
This enables the service to build the response before sending a HTTP response to the consumer. Previous implementation starts streaming data right away starting with a HTTP 200 response, and it's not possible to return HTTP 413 later on.
_Note: This could result in memory spikes._

2. `MAXIMUM_BYTES_RETURNED = 0` will still allow streaming and avoid memory spikes. 
_Note: Please refer to MongoDB limitations on open cursor and maximum document size that can be returned._

Example query (with `MAXIMUM_BYTES_RETURNED = 10e3` for demonstration),

```bash
$ curl --request GET \
  --url 'http://localhost:3000/eidaws/wfcatalog/1/query?network=NL&station=G233&include=sample&start=2024-01-01&end=2024-01-31'

Error 413: Payload Too Large
The requested payload exceeds the service limitation
Usage details are available from ENTER_URI_HERE
Request:
/eidaws/wfcatalog/1/query?network=NL&station=G233&include=sample&start=2024-01-01&end=2024-01-31
Request Submitted:
Fri Feb 20 2026 09:01:37 GMT+0100 (Midden-Europese standaardtijd)
Service Version:
1.0.3
```


### Other explored solutions

1. Pagination: Ideally, it would be great if the responses could be paginated. This will allow consumers to incrementally query the API/Database providing a much pleasant experience. However, this requires considerable overhaul of the current API design.

